### PR TITLE
Fix cross-platform import and test script

### DIFF
--- a/shell_tool.py
+++ b/shell_tool.py
@@ -28,9 +28,13 @@ import logging
 import tempfile
 import threading
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from datetime import datetime, timedelta
-import winreg
+
+try:
+    import winreg  # Windows registry access
+except ImportError:  # Not on Windows
+    winreg = None
 import psutil
 import shutil
 from concurrent.futures import ThreadPoolExecutor

--- a/test_script.py
+++ b/test_script.py
@@ -112,7 +112,7 @@ def test_tool_methods():
         from code_analysis_tool import CodeAnalysisTool
         tool = CodeAnalysisTool()
         # Just check instantiation and method presence
-        assert hasattr(tool, 'bb7_analyze_code_complete')
+        assert hasattr(tool, 'bb7_analyze_code')
         print("  ✅ CodeAnalysisTool methods present")
     except Exception as e:
         print(f"  ❌ CodeAnalysisTool method test failed: {e}")


### PR DESCRIPTION
## Summary
- avoid ImportError on Linux by making `winreg` optional
- fix CodeAnalysisTool method check in test suite

## Testing
- `python test_script.py`


------
https://chatgpt.com/codex/tasks/task_e_684f79753c5c8329b4df2d9929e61652

## Summary by Sourcery

Make the winreg module import optional to support non-Windows platforms and correct the test script to check the updated method name in CodeAnalysisTool.

Bug Fixes:
- Make winreg import optional in shell_tool to prevent ImportError on Linux.
- Update test_script to assert the presence of bb7_analyze_code instead of the outdated bb7_analyze_code_complete method.